### PR TITLE
增加全局配置文件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 venv
 uploads
+config.yml

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -1,0 +1,5 @@
+openAccessKeys:
+  aliOss:
+    keyID: LTAI5tKqJUc7ejKyTDjr88kJ
+    keySecret: RM8NJIxK38FnPxJwzpQnJywkTI4wc5
+

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -1,5 +1,8 @@
+# 开放AK授权
 openAccessKeys:
   aliOss:
-    keyID: LTAI5tKqJUc7ejKyTDjr88kJ
-    keySecret: RM8NJIxK38FnPxJwzpQnJywkTI4wc5
+    keyID: 8dj39skcr940sxjcrirod
+    keySecret: 98e0djcmwleicnc9ednc
+    endPoint: oss-cn-beijing.aliyuncs.com
+    bucketName: oss-test
 

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 from flask import Flask, jsonify, request
-from src import success, fail, putObject
+from src import success, fail, putObject, loadConfig
 from werkzeug.utils import secure_filename
 import os
 
@@ -15,9 +15,11 @@ uploadsDir = os.path.join(os.getcwd(), 'uploads')
 os.makedirs(uploadsDir, exist_ok=True)
 
 
-@app.route('/upload', methods=['POST'])
+@app.route('/', methods=['POST'])
 def uploadHandler():
-    return jsonify([{'a': 1, 'c': 3, 'b': 2, 'e': 5, 'd': 4}])
+    ossConnInfo = loadConfig()
+    # print(ossConnInfo.get('openAccessKeys'))
+    return jsonify(loadConfig())
 
 
 @app.route('/file/upload', methods=['POST'])

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,2 +1,3 @@
 from .response import success, fail
 from .ossutil import putObject
+from .config import loadConfig

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,11 @@
+import yaml
+import os
+
+def loadConfig():
+    print('正在加载配置文件...')
+    configFile = open(os.path.join(os.getcwd(), 'config.yml'), 'r')
+    print(os.path.join(os.getcwd(), 'config.yml'))
+    configYaml = yaml.safe_load(configFile)
+    print(configYaml)
+    print('解析完成')
+    return configYaml

--- a/src/ossutil.py
+++ b/src/ossutil.py
@@ -1,10 +1,14 @@
 import oss2
 import os
+from .config import loadConfig
 
-AccessKeyID = 'LTAI5tKqJUc7ejKyTDjr88kJ'
-AccessKeySecret = 'RM8NJIxK38FnPxJwzpQnJywkTI4wc5'
-bucketName = 'jinwei-test'
-endPoint = 'oss-cn-beijing.aliyuncs.com'
+aliOss = loadConfig().get('openAccessKeys').get('aliOss')
+print(aliOss)
+AccessKeyID = aliOss.get('keyID')
+AccessKeySecret = aliOss.get('keySecret')
+endPoint = aliOss.get('endPoint')
+bucketName = aliOss.get('bucketName')
+print(AccessKeyID, AccessKeySecret)
 
 
 auth = oss2.Auth(AccessKeyID, AccessKeySecret)


### PR DESCRIPTION
由于需要授权公有云对象存储，将敏感数据都运行时配置